### PR TITLE
Add plot bands for weekends in efficiency plot

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,30 @@ function fullEfficiencyChart(data) {
         // normalizedData.push([new Date(point[0]).getTime(), point[4]]);
     });
 
+    // Calculate weekend dates.
+    // NB: Assumes points are sorted.
+    var endDate = new Date(data[data.length - 1][0]);
+    endDate.setHours(0, 0, 0, 0);
+
+    var minDate = new Date(data[0][0]);
+    // We want to start on a Saturday
+    var delta = 6 - minDate.getDay();
+    var curDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate() + delta);
+
+    var weekendBands = [];
+    while (curDate <= endDate) {
+        var bandEnd = addDays(curDate, 1);
+        bandEnd.setHours(23, 59, 59, 0);
+        weekendBands.push({
+            color: 'rgba(180, 180, 180, 0.6)',
+            from: curDate.getTime(),
+            to: bandEnd.getTime(),
+            type: 'datetime'
+        });
+
+        curDate.setDate(curDate.getDate() + 7);
+    }
+
 
     $('#efficiency_chart').highcharts('StockChart', {
         chart: {
@@ -213,7 +237,11 @@ function fullEfficiencyChart(data) {
                 loessSmooth: parseInt(document.getElementById("trendLineSpinner").value,10)
 
             },
-        }]
+        }],
+
+        xAxis: {
+            plotBands: weekendBands
+        }
     });
     Highcharts.setOptions(Highcharts.theme);
 
@@ -523,4 +551,10 @@ function timeFormatter(totalSeconds) {
     var minutes = parseInt(totalSeconds / 60, 10) % 60;
     var seconds = totalSeconds % 60;
     return (hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds);
+}
+
+function addDays(date, days) {
+    var result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
 }

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                         <br>(Time*RescueTime's Productivity Score)/3600.
                         <br>This means that if you do 60 minutes with 100 as Productivity Score your productivity will be 100 too, but if you do only 30 minutes with 100 Productivity Score your productivity will be 50!
                         <br> You can think at blue line as the things you got done.
+                        <br> Weekends are shown with gray plot bands.
                     </p>
 
                 </blockquote>


### PR DESCRIPTION
I added gray plot bands to the efficiency trend plot. This helped in my own time analysis and I figure it would help others, too! Here's [a photo](https://dl.dropboxusercontent.com/u/7338/rescuetime-again%20plot%20bands.png):

![With plot bands.](https://dl.dropboxusercontent.com/u/7338/rescuetime-again%20plot%20bands.png)

Some of the bands seem a bit smaller than the others; I think this is due to a limitation of Highcharts — the band start-points / end-points are aligned to the nearest available data point, as far as I can see.

Thanks a lot for creating this tool!