### PR TITLE
Added support for saving API Key in local storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,20 @@ var queries = {
     }
 };
 
+//check for local storage
+var ls =  {
+    get: function () { 
+        var test = 'test';
+        try {
+            localStorage.setItem(test, test);
+            localStorage.removeItem(test);
+            return true;
+        } catch(e) {
+            return false;
+        }
+    }
+};
+
 
 $("document").ready(function() {
     //handling upload event
@@ -33,11 +47,37 @@ $("document").ready(function() {
         activityChart(rawActivityData);
     });
 
+    //if a key is saved, load it in the 'Enter API key' field
+    if (ls) {
+    	// We can use localStorage 
+        if(!localStorage.getItem('rescuetimeApiKey')) {
+            //no stored API Key
+            console.log("No stored API Key");
+        } else {
+            key = localStorage.getItem('rescuetimeApiKey');
+            document.getElementById('api_key').value = key;
+            document.getElementById('api_key').placeholder = '';
+            console.log("retrieving key from storage");
+        }
+    }
 });
+
+function storeKey(key) {
+    if (ls) {
+        localStorage.setItem('rescuetimeApiKey', key);
+        console.log("Saving key");
+    }
+}
 
 
 function init() {
     var key = document.getElementById('api_key').value.trim();
+
+    // Only store the key if the save box is checked
+    if (document.getElementById('save').checked) {
+        storeKey(key);
+    }
+
     if (key.length > 5) {
         usingFiles = false;
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
                 <button type="button" class="btn btn-primary" onClick="init()">Start analysis</button>
                 <div class="checkbox">
                     <label>
-                        <input type="checkbox" id="download"> Download JSON file for the selected range. <a href="https://github.com/ilbonte/rescuetime-again#notes" target="_blank">Why?</a>
+                        <input type="checkbox" id="download"> Download JSON file for the selected range. <a href="https://github.com/ilbonte/rescuetime-again#notes" target="_blank">Why?</a><br>
+                        <input type="checkbox" id="save" checked> Save API Key</a>
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
#11 
* If there is an existing API Key saved, it will be automatically loaded. This saved API key can be overridden by saving something over it (can only save one API key per browser). 
* Default setting is to save an API Key, though this may be toggled. (Save API Key Checkbox Below).
<img width="1080" alt="Save API Key Checkbox" src="https://cloud.githubusercontent.com/assets/10334556/21575398/c43c1730-cebf-11e6-9a20-595daacabd68.png">