### PR TITLE
change CORS proxy service

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,7 +105,7 @@ function init() {
 //get the data using rescuetime api
 function getData(params) {
     var rescuetimeAPI = 'https://www.rescuetime.com/anapi/data?';
-    $.getJSON('https://cors-anywhere.herokuapp.com/' + rescuetimeAPI, {
+    $.getJSON('https://cors.bridged.cc/' + rescuetimeAPI, {
         key: params.key,
         perspective: params.perspective,
         restrict_kind: params.restrict_kind,


### PR DESCRIPTION
The https://cors-anywhere.herokuapp.com/ Is downgraded to demo usage only (see [this ](https://github.com/Rob--W/cors-anywhere/issues/301)for more info). So the user must visit a page at cors-anywhere.herokuapp.com to temporarily unlock the demo for their browser. In order not to force the user to do this every time, an alternative was found.